### PR TITLE
Fix getenv() not working with .env.local.php

### DIFF
--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -7,6 +7,9 @@ require dirname(__DIR__).'/vendor/autoload.php';
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
 if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
+    foreach ($env as $name => $value) {
+        putenv("$name=$value");
+    }
     $_SERVER += $env;
     $_ENV += $env;
 } elseif (!class_exists(Dotenv::class)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

When dumping the env using Flex 1.2 ``dump-env`` the getenv function does no longer work for these variables.
This is a quick fix just like it is done in ``DotEnv::populate``, but might need further review.
